### PR TITLE
Add drupal behaviour for init. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# highlightjs
+
+## Configuration
+
+Check the file ./js/highlightjsInit.js in order to change selectors. Currently hilighting every &lt;code&gt;&lt;/code&gt; tag.
+
+Change 'code' in the following line to your selector. 
+
+````
+ $('code', context) ...
+````
+
+Highlightjs defaults is: &lt;pre&gt;<code&gt;&lt;/code&gt;&lt;/pre&gt;.
+
+Which would result:
+
+````
+ $('pre code', context) ...
+````
+
+Libraries in this module are loaded from cdnjs.cloudflare.com
+See: ./highlightjs.libraries.yml
+
+## Read more
+
+https://highlightjs.org/usage/
+
+http://highlightjs.readthedocs.org/en/latest/

--- a/js/highlightjsInit.js
+++ b/js/highlightjsInit.js
@@ -1,1 +1,13 @@
-hljs.initHighlightingOnLoad();
+(function ($, Hljs, Drupal) {
+  'use strict';
+
+  Drupal.behaviors.hljs = {
+    attach: function (context, settings) {
+
+      $('code', context).once('hljs').each(function (i, block) {
+        Hljs.highlightBlock(block);
+      });
+    }
+  };
+
+})(jQuery, window.hljs, window.Drupal);


### PR DESCRIPTION
Compared to default it will run on <code> instead of <pre><code> markup.
Add drupal behaviour support in order to have hilighting on Ajax calls.

This will fix inline editing too: Hilighting is reapplied after saving content.
